### PR TITLE
Make `expt` work for complexes

### DIFF
--- a/lib/R5RS.scm
+++ b/lib/R5RS.scm
@@ -27,7 +27,6 @@
 (define -inf.0 Number.NEGATIVE_INFINITY)
 (define +inf.0 Number.POSITIVE_INFINITY)
 (define procedure? function?)
-(define expt **)
 (define list->vector list->array)
 (define vector->list array->list)
 (define call-with-current-continuation call/cc)
@@ -482,6 +481,15 @@
          (make-rectangular (* factor (cos im))
                            (* factor (sin im))))
        (Math.exp x)))
+
+;; -----------------------------------------------------------------------------
+(define (expt x y)
+  (typecheck "exp" x "number")
+  (typecheck "exp" y "number")
+  (if (or (string=? x.__type__ "complex")
+          (string=? y.__type__ "complex"))
+      (exp (* (log x) y))
+      (** x y)))
 
 ;; -----------------------------------------------------------------------------
 (define (modulo a b)


### PR DESCRIPTION
Previously LIPS did `(define expt **)`; we make `expt` work for complexes by changing the definition to use `(exp (* (log x) y))` if any of the arguments is complex. It still doesn't work for rationals, but that looks like a larger problem.

I'm really not sure this PR is useful -- I'm ok with it if you want to close it, since it only enhances a tiny bit, and doesn't make the procedure (`expt`) fully functional. At least I got to know a bit more of LIPS' internals. :)
