### PR TITLE
Replace `**NOTE**` with `:::info` in docs

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -31,10 +31,14 @@ After adding the script tag with the main file, you can use Scheme code within a
 </script>
 ```
 
-**NOTE**: Only the core of LIPS is written in JavaScript, almost half of it it's written in Scheme.
+:::info
+
+Only the core of LIPS is written in JavaScript, almost half of it it's written in Scheme.
 So if you want to load the standard library (to have full LIPS), you should use `bootstrap` or
 `data-bootstrap` attribute that will load it for you. You can optionally specify the location of the
 file.
+
+:::
 
 ```html
 <script type="text/x-scheme" bootstrap="https://cdn.jsdelivr.net/npm/@jcubic/lips@beta/dist/std.xcb">
@@ -48,7 +52,11 @@ file.
 `xcb` file is simple binary format that LIPS uses to speed up parsing the the code. You can also use
 `.scm` file or `.min.scm` file that may be little bit bigger.
 
-**NOTE** The `bootstrap` attribute can also be included on main script tag with the JavaScript file.
+:::info
+
+The `bootstrap` attribute can also be included on main script tag with the JavaScript file.
+
+:::
 
 ### Running External Scheme Code
 
@@ -141,8 +149,12 @@ and execute the script by providing the name:
 ./script.scm
 ```
 
-**NOTE**: by default most systems don't execute files in current directory so you need to provide `./` in front.
+:::info
+
+by default most systems don't execute files in current directory so you need to provide `./` in front.
 You can change that if you add dot (current working directory) to the `$PATH` environment variable:
+
+:::
 
 ```bash
 export $PATH=".:$PATH"
@@ -156,8 +168,12 @@ If you prefer to install lips locally instead of globally you can use this sheba
   (print (string-append "Hello " what)))
 ```
 
-**NOTE**: if you run this code outside of [Node.js project](#nodejs-project) npx will install the
+:::info
+
+if you run this code outside of [Node.js project](#nodejs-project) npx will install the
 package before execution.
+
+:::
 
 ### Node.js project
 
@@ -186,9 +202,13 @@ and use them in LIPS Scheme:
 ;; ==> #("01" "02" "03" "04" "05" "06" "07" "08" "09" "10")
 ```
 
-**NOTE**: [braces](https://www.npmjs.com/package/braces) is a popular package to expand bash like
+:::info
+
+[braces](https://www.npmjs.com/package/braces) is a popular package to expand bash like
 expressions, it's used as [deep dependency for
 TailwindCSS](https://shubhamjain.co/2024/02/29/why-is-number-package-have-59m-downloads/).
+
+:::
 
 ## Executing LIPS prammatically
 
@@ -242,7 +262,11 @@ The Interpreter have a method `exec` that work the same as thhe one exported fro
 
 ### Bootstrapping
 
-**Note**: that you also need to bootstrap the standard library to have fully working Scheme system.
+:::info
+
+that you also need to bootstrap the standard library to have fully working Scheme system.
+
+:::
 
 ```javascript
 await interpreter.exec(`(let-env lips.env.__parent__

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -151,7 +151,7 @@ and execute the script by providing the name:
 
 :::info
 
-by default most systems don't execute files in current directory so you need to provide `./` in front.
+By default most systems don't execute files in current directory so you need to provide `./` in front.
 You can change that if you add dot (current working directory) to the `$PATH` environment variable:
 
 :::
@@ -170,7 +170,7 @@ If you prefer to install lips locally instead of globally you can use this sheba
 
 :::info
 
-if you run this code outside of [Node.js project](#nodejs-project) npx will install the
+If you run this code outside of [Node.js project](#nodejs-project) npx will install the
 package before execution.
 
 :::
@@ -264,7 +264,7 @@ The Interpreter have a method `exec` that work the same as thhe one exported fro
 
 :::info
 
-that you also need to bootstrap the standard library to have fully working Scheme system.
+Note that you also need to bootstrap the standard library to have fully working Scheme system.
 
 :::
 

--- a/docs/docs/lips/environments.md
+++ b/docs/docs/lips/environments.md
@@ -51,7 +51,7 @@ You can use this function in LIPS with version 5 and 7 to get R<sup>5</sup>RS or
 
 :::info
 
-that some of the functions from R<sup>5</sup>RS may have features of R<sup>7</sup>RS since
+Note that some of the functions from R<sup>5</sup>RS may have features of R<sup>7</sup>RS since
 some of them got additional arguments. R<sup>n</sup>RS is backward compatible.
 
 :::

--- a/docs/docs/lips/environments.md
+++ b/docs/docs/lips/environments.md
@@ -49,8 +49,12 @@ specification](/docs/scheme-intro/what-is-lisp#standards) in a form of a functio
 
 You can use this function in LIPS with version 5 and 7 to get R<sup>5</sup>RS or R<sup>7</sup>RS.
 
-**NOTE**: that some of the functions from R<sup>5</sup>RS may have features of R<sup>7</sup>RS since
+:::info
+
+that some of the functions from R<sup>5</sup>RS may have features of R<sup>7</sup>RS since
 some of them got additional arguments. R<sup>n</sup>RS is backward compatible.
+
+:::
 
 You can use this function with `eval` or `let-env`:
 

--- a/docs/docs/lips/extension.md
+++ b/docs/docs/lips/extension.md
@@ -127,7 +127,11 @@ To see the expansion of syntax extension you can use `lips.parse`:
 ;; ==> #((list 10 10))
 ```
 
-**NOTE**: The `lips.parse` function return array/vector of parsed expressions.
+:::info
+
+The `lips.parse` function return array/vector of parsed expressions.
+
+:::
 
 There are 3 types of syntax extensions `SPLICE`, `LITERAL`, and `SYMBOL`. You define them using
 constants defined in `lips.specials` object.
@@ -286,8 +290,12 @@ extension that return line number:
 ;; ==> (12 13)
 ```
 
-**NOTE**: The provided output will be exactly the same, when the code will be put into a single file
+:::info
+
+The provided output will be exactly the same, when the code will be put into a single file
 and executed.
+
+:::
 
 ### Standard input
 In syntax extensions `current-input-port` points into the parser stream. So you can implement

--- a/docs/docs/lips/functional-helpers.md
+++ b/docs/docs/lips/functional-helpers.md
@@ -277,7 +277,7 @@ as `fold-left`. Both procedures works similarly. The take a procedure and a list
 
 :::info
 
-the reduce works differently than in JavaScript, the callback function get accumulator in last argument.
+The reduce works differently than in JavaScript, the callback function get accumulator in last argument.
 
 :::
 
@@ -318,7 +318,7 @@ Same as reduce it accept more than one list:
 
 :::info
 
-here we use `cons` to create a list, `cons` construct the list in reverse order so `reduce`
+Here we use `cons` to create a list, `cons` construct the list in reverse order so `reduce`
 start from first element and `fold` is reversed:
 
 :::

--- a/docs/docs/lips/functional-helpers.md
+++ b/docs/docs/lips/functional-helpers.md
@@ -199,8 +199,12 @@ Let's create a macro that will count how many times the code is executed:
          (console.timeEnd ,label))))))
 ```
 
-**NOTE** `#:result` expression is [auto gensym](/docs/lips/extension#autogensyms) as one of
+:::info
+
+`#:result` expression is [auto gensym](/docs/lips/extension#autogensyms) as one of
 builtin [syntax extensions](/docs/lips/extension#syntax-extensions).
+
+:::
 
 We can use this code to make sure that the function has been executed only once:
 
@@ -271,7 +275,11 @@ The code removes the zeros from list before applying the fraction that will thro
 LIPS define function `reduce` that is an alias to standard Scheme procedure `fold-right` and fold that is the same
 as `fold-left`. Both procedures works similarly. The take a procedure and a list and reduce it into a single value.
 
-**NOTE** the reduce works differently than in JavaScript, the callback function get accumulator in last argument.
+:::info
+
+the reduce works differently than in JavaScript, the callback function get accumulator in last argument.
+
+:::
 
 
 ```scheme
@@ -308,8 +316,12 @@ Same as reduce it accept more than one list:
 ;; ==> (1 "foo" 2 "bar" 3 "baz" 4 "quuz")
 ```
 
-**NOTE**: here we use `cons` to create a list, `cons` construct the list in reverse order so `reduce`
+:::info
+
+here we use `cons` to create a list, `cons` construct the list in reverse order so `reduce`
 start from first element and `fold` is reversed:
+
+:::
 
 ```scheme
 (reduce (lambda (item acc)

--- a/docs/docs/lips/intro.md
+++ b/docs/docs/lips/intro.md
@@ -484,7 +484,7 @@ This is equivalent of:
 
 :::info
 
-the only time when you still need `.` function is when you want to get the property of
+The only time when you still need `.` function is when you want to get the property of
 object returned by expression.
 
 :::
@@ -500,7 +500,7 @@ reference to the DOM node.
 
 :::info
 
-because dot notation in symbols is not special syntax you can use code like this:
+Because dot notation in symbols is not special syntax you can use code like this:
 
 :::
 
@@ -560,7 +560,7 @@ in JavaScript:
 
 :::info
 
-the values in JavaScript are different because they have different representation in LIPS.
+The values in JavaScript are different because they have different representation in LIPS.
 
 :::
 
@@ -672,7 +672,7 @@ You can also use quasiquote with object literals:
 
 :::info
 
-because of the construction of [syntax extensions](/docs/lips/extension#syntax-extensions) and
+Because of the construction of [syntax extensions](/docs/lips/extension#syntax-extensions) and
 [quasiquote](/docs/scheme-intro/data-types#quasiquote), you can't splice a list inside object literals:
 
 :::
@@ -717,7 +717,7 @@ The same you can use macros that will return LIPS Scheme code:
 
 :::info
 
-this example macro works the same `object` is it's not that useful, but you can create
+This example macro works the same `object` is it's not that useful, but you can create
 more complex code where you will be able to generate object literals with splicing.
 
 :::
@@ -879,7 +879,7 @@ You can also define `finally` without `catch`:
 
 :::info
 
-the order of execution is not expected, but it may change in the future.
+The order of execution is not expected, but it may change in the future.
 
 :::
 
@@ -928,7 +928,7 @@ float if used on normal vector:
 
 :::info
 
-be careful when using iterator protocol because any function side Scheme can return a promise. If you would change
+Be careful when using iterator protocol because any function side Scheme can return a promise. If you would change
 quoted object literal `` `&() `` with longhand `object` you will get an error because `object` is async.
 
 :::
@@ -1097,7 +1097,7 @@ loading `.xcb` or `.scm` files.
 
 :::info
 
-directives `#!fold-case` and `#!no-fold-case` work only inside the parser and they are
+Directives `#!fold-case` and `#!no-fold-case` work only inside the parser and they are
 treated as comments, so you can't compile the code that have those directives.
 
 :::

--- a/docs/docs/lips/intro.md
+++ b/docs/docs/lips/intro.md
@@ -230,7 +230,11 @@ There is also another function to check type of number:
 ;; ==> Expecting bigint got complex in expression `let`
 ```
 
-**NOTE**: In LIPS all integers are BigInts.
+:::info
+
+In LIPS all integers are BigInts.
+
+:::
 
 The last typecking function is `typecheck-args` that check if all arguments are of same type.
 
@@ -478,8 +482,12 @@ This is equivalent of:
 (document.querySelector "body")
 ```
 
-**NOTE** the only time when you still need `.` function is when you want to get the property of
+:::info
+
+the only time when you still need `.` function is when you want to get the property of
 object returned by expression.
+
+:::
 
 ```scheme
 (let ((style (. (document.querySelector "body") 'style)))
@@ -490,7 +498,11 @@ Here we get a [style object](https://developer.mozilla.org/en-US/docs/Web/API/HT
 from [the DOM node](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) without sorting the
 reference to the DOM node.
 
-**NOTE** because dot notation in symbols is not special syntax you can use code like this:
+:::info
+
+because dot notation in symbols is not special syntax you can use code like this:
+
+:::
 
 ```scheme
 (let ((x #(1 2 3)))
@@ -658,8 +670,12 @@ You can also use quasiquote with object literals:
 ;; ==> &(:name "Jack" :age 22)
 ```
 
-**NOTE**: because of the construction of [syntax extensions](/docs/lips/extension#syntax-extensions) and
+:::info
+
+because of the construction of [syntax extensions](/docs/lips/extension#syntax-extensions) and
 [quasiquote](/docs/scheme-intro/data-types#quasiquote), you can't splice a list inside object literals:
+
+:::
 
 ```scheme
 (let ((args (list ':foo "lorem" ':bar "ipsum")))
@@ -699,8 +715,12 @@ The same you can use macros that will return LIPS Scheme code:
 ;; ==> &(:foo "lorem" :bar "ipsum")
 ```
 
-**NOTE**: this example macro works the same `object` is it's not that useful, but you can create
+:::info
+
+this example macro works the same `object` is it's not that useful, but you can create
 more complex code where you will be able to generate object literals with splicing.
+
+:::
 
 Object literal also have shorthad notation:
 
@@ -773,7 +793,11 @@ automatic async/await you can use `(await)` procedure
 ;; ==> Scheme is Super Fun
 ```
 
-**NOTE** Inside `then` lambda promises are still automagically resolved.
+:::info
+
+Inside `then` lambda promises are still automagically resolved.
+
+:::
 
 ```scheme
 (--> '>(Promise.resolve "hello")
@@ -853,7 +877,11 @@ You can also define `finally` without `catch`:
 ;; ==> nasty
 ```
 
-**NOTE** the order of execution is not expected, but it may change in the future.
+:::info
+
+the order of execution is not expected, but it may change in the future.
+
+:::
 
 LIPS also define R<sup>7</sup>RS guard `procedure` that is just a macro that use try..catch behind the scene:
 
@@ -898,8 +926,12 @@ float if used on normal vector:
 ;; ==> #(0.5 0.3333333333333333 0.25 0.2)
 ```
 
-**NOTE**: be careful when using iterator protocol because any function side Scheme can return a promise. If you would change
+:::info
+
+be careful when using iterator protocol because any function side Scheme can return a promise. If you would change
 quoted object literal `` `&() `` with longhand `object` you will get an error because `object` is async.
+
+:::
 
 You can abstract the use of iteration protocol with a macro, but to have real `yield` keyword like
 syntax you need `call/cc`.
@@ -1063,8 +1095,12 @@ $ lips -c file.xcb
 Will create `file.xcb` in same directory. For smaller files it make not have a difference when
 loading `.xcb` or `.scm` files.
 
-**NOTE**: directives `#!fold-case` and `#!no-fold-case` work only inside the parser and they are
+:::info
+
+directives `#!fold-case` and `#!no-fold-case` work only inside the parser and they are
 treated as comments, so you can't compile the code that have those directives.
+
+:::
 
 ## loading SRFI
 

--- a/docs/docs/scheme-intro/macros.md
+++ b/docs/docs/scheme-intro/macros.md
@@ -197,9 +197,13 @@ You can call this macro to create alist based on its arguments:
 ;; ==> (("foo" . 10) ("bar" . 20) ("baz" . 30))
 ```
 
-**Note** recursive call is inside quote and only argument is unquoted. This is required since
+:::info
+
+recursive call is inside quote and only argument is unquoted. This is required since
 recursive macro call needs to appear in the expansion. If you call macro recursively and don't return
 macro call as output list you will end up in ifninite recursive call.
+
+:::
 
 You can see the macro will expand with macroexpand:
 
@@ -543,8 +547,12 @@ The output may be different depending on implementation.
 By default Scheme `syntax-rules` macros don't allow creating anaphoric macros like lisp macro do.
 But with [SRFI-139](https://srfi.schemers.org/srfi-139/srfi-139.html) you can implement such macros.
 
-**Note**: that not every scheme implementation support this <abbr title="Scheme Request For
+:::info
+
+that not every scheme implementation support this <abbr title="Scheme Request For
 Implementation">SRFI</abbr>.
+
+:::
 
 Here is example of `awhen` anaphoric macro that use this <abbr title="Scheme Request For
 Implementation">SRFI</abbr>:

--- a/docs/docs/scheme-intro/macros.md
+++ b/docs/docs/scheme-intro/macros.md
@@ -199,7 +199,7 @@ You can call this macro to create alist based on its arguments:
 
 :::info
 
-recursive call is inside quote and only argument is unquoted. This is required since
+Recursive call is inside quote and only argument is unquoted. This is required since
 recursive macro call needs to appear in the expansion. If you call macro recursively and don't return
 macro call as output list you will end up in ifninite recursive call.
 
@@ -549,7 +549,7 @@ But with [SRFI-139](https://srfi.schemers.org/srfi-139/srfi-139.html) you can im
 
 :::info
 
-that not every scheme implementation support this <abbr title="Scheme Request For
+Note that not every scheme implementation support this <abbr title="Scheme Request For
 Implementation">SRFI</abbr>.
 
 :::

--- a/docs/docs/scheme-intro/next-step.md
+++ b/docs/docs/scheme-intro/next-step.md
@@ -58,8 +58,13 @@ If you want to learn more about lisp macros, there are two great books:
 
 ## Scheme hygienic macros
 
-**NOTE**: Unfortunately, there are no good books about Scheme hygienic macros.  But you can read
+:::info
+
+Unfortunately, there are no good books about Scheme hygienic macros.  But you can read
 those documents:
+
+:::
+
 * [Writing Powerful Macros in Scheme](https://github.com/mnieper/scheme-macros) by [Marc
 Nieper-Wißkirchen](https://github.com/mnieper).
 * [JRM’s Syntax-rules Primer for the Merely Eccentric](http://www.phyast.pitt.edu/~micheles/syntax-rules.pdf)

--- a/docs/docs/scheme-intro/what-is-lisp.md
+++ b/docs/docs/scheme-intro/what-is-lisp.md
@@ -99,7 +99,7 @@ And you can type your scheme code and press enter to execute it (it's often call
 
 :::info
 
-you can run [LIPS bookmarklet](/#bookmark) while reading this tutorial. But note that it
+You can run [LIPS bookmarklet](/#bookmark) while reading this tutorial. But note that it
 doesn't yet support [continuations](/docs/scheme-intro/continuations) and TCO ([Tail Call
 Optimization](/docs/scheme-intro/core#tail-call-optimization)).
 

--- a/docs/docs/scheme-intro/what-is-lisp.md
+++ b/docs/docs/scheme-intro/what-is-lisp.md
@@ -39,7 +39,11 @@ write the same expression as:
 
 Is that in Lisp there are no operators. The above expression is just procedure application (function call).
 
-**NOTE**: We will use procedure and function interchangeably in this tutorial.
+:::info
+
+We will use procedure and function interchangeably in this tutorial.
+
+:::
 
 Plus is not an operator, only a symbol that point into an addition procedure that is executed. So in
 fact in other programming languages this should be written as:
@@ -93,9 +97,13 @@ scheme>
 
 And you can type your scheme code and press enter to execute it (it's often called evaluation of the expression).
 
-**NOTE**: you can run [LIPS bookmarklet](/#bookmark) while reading this tutorial. But note that it
+:::info
+
+you can run [LIPS bookmarklet](/#bookmark) while reading this tutorial. But note that it
 doesn't yet support [continuations](/docs/scheme-intro/continuations) and TCO ([Tail Call
 Optimization](/docs/scheme-intro/core#tail-call-optimization)).
+
+:::
 
 ### Standards
 


### PR DESCRIPTION
#### Reference Issues / PRs

closes #420

#### What does this implement/fix?

Replaces all the instance of `**NOTE**` with `:::info` in the docs

#### Any other comments?

No