### PR TITLE
Fix crash when using CSP that prevents unsafe-eval

### DIFF
--- a/src/lips.js
+++ b/src/lips.js
@@ -6353,8 +6353,8 @@ var pow = function(a, b) {
 // -------------------------------------------------------------------------
 // use native exponential operator if possible (it's way faster)
 // -------------------------------------------------------------------------
-var exp_op = new Function('a,b', 'return a ** b');
 try {
+    var exp_op = new Function('a,b', 'return a ** b');
     if (exp_op(2, 2) === 4) {
         pow = exp_op;
     }


### PR DESCRIPTION
This is a fix for a crash I encountered while trying to use LIPS in my browser extension. Manifest V3 web extensions [have a default content security policy](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#default_content_security_policy) which causes `eval(...)` and `new Function(...)` to throw exceptions. The crash happened at this top level call to `new Function(...)`. After I made this change locally, I was able to successfully load LIPS in my extension.