### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -210,7 +210,7 @@ TailwindCSS](https://shubhamjain.co/2024/02/29/why-is-number-package-have-59m-do
 
 :::
 
-## Executing LIPS prammatically
+## Executing LIPS programatically
 
 You can also execute LIPS from JavaScript:
 


### PR DESCRIPTION
I think that there is a typo in the Getting Started section... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the programming guide section heading.
  * Added a JavaScript usage example demonstrating how to execute LIPS expressions and handle Promise results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->