### PR TITLE
fix(package): correct misspelled peerDependencies key

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,8 +248,8 @@
     "typescript": "^5.9.3",
     "uglify-js": "^3.19.3"
   },
-  "peerDepencies": {
-    "cbor-extract": "^0.3.1",
+  "peerDependencies": {
+    "cbor-extract": "^2.2.0",
     "bn.js": "^5.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
## What

`package.json` declares the field as `peerDepencies` (missing "nd"), which npm silently ignores — so the intended peer constraints for `cbor-extract` and `bn.js` were never applied.

## Changes

- Renamed the key to `peerDependencies`.
- Aligned the `cbor-extract` peer range with the version already used in `dependencies` (`^2.2.0` instead of the stale `^0.3.1`), so the corrected field doesn't conflict with the direct dependency.

No other fields touched.