### PR TITLE
docs: document callable `|.|` dot operator form

### DIFF
--- a/docs/docs/lips/intro.md
+++ b/docs/docs/lips/intro.md
@@ -487,6 +487,16 @@ This returned function querySelector from document object in browser. Note that 
 as first element of the list (it's handled in special way by the parser). In any other place dot is a pair separator,
 see documentation about [Pairs in Scheme](/docs/scheme-intro/data-types#pairs).
 
+To reference the dot function as a value, use the escaped symbol `|.|`. This lets you pass it to
+higher-order functions such as `curry`:
+
+```scheme
+(define doc (curry |.| document))
+((doc 'querySelector) "body")
+;; ==> #<HTMLBodyElement>
+```
+
+Here `|.|` refers to the same function as `.` without triggering the parser's special handling.
 
 ##### Usage of `.` operators
 


### PR DESCRIPTION
## Summary

- Document how the escaped `|.|` symbol exposes the dot operator as a first-class value.
- Add a concise `curry` example that mirrors the issue reproduction.

Closes #551

## Validation

- `cd docs && npm run build`
- `uvx codespell docs/docs/lips/intro.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded dot operator guidance with examples for escaping `.` as `|.|.
  * Documented passing the escaped symbol to `curry` and using the resulting function to access object properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->