### PR TITLE
docs: document using the dot function as a value via |.|

### DIFF
--- a/docs/docs/lips/intro.md
+++ b/docs/docs/lips/intro.md
@@ -513,6 +513,16 @@ This returned function querySelector from document object in browser. Note that 
 as first element of the list (it's handled in special way by the parser). In any other place dot is a pair separator,
 see documentation about [Pairs in Scheme](/docs/scheme-intro/data-types#pairs).
 
+If you need the dot function as a value — for example to curry it into a reusable getter — you can
+write it with pipe characters, `|.|`. Inside pipes the dot is parsed as a plain symbol instead of a
+pair separator:
+
+```scheme
+(define doc (curry |.| document))
+((doc 'querySelector) "body")
+;; ==> #<HTMLBodyElement>
+```
+
 
 ##### Usage of `.` operators
 


### PR DESCRIPTION
Closes #551

Problem:
- The dot-operator docs explain that `.` can only appear as the first element of a list, but not how to use it as a plain value (e.g. to curry it into a getter).

Solution:
- Added a short paragraph to the "The dot operator" section in `docs/docs/lips/intro.md` documenting the `|.|` form, with the curry example from the issue.

Result:
- Verified the example against the interpreter first (`node bin/lips.js`): `(define doc (curry |.| document))` then `((doc 'querySelector) "body")` works as documented.
- `npm run build` in `docs/` passes (Docusaurus).
